### PR TITLE
Can bypassing confirm when creating new user now

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -854,7 +854,13 @@ class User(GitlabObject):
     requiredCreateAttrs = ['email', 'username', 'name']
     optionalCreateAttrs = ['password', 'skype', 'linkedin', 'twitter',
                            'projects_limit', 'extern_uid', 'provider',
-                           'bio', 'admin', 'can_create_group', 'website_url']
+                           'bio', 'admin', 'can_create_group', 'website_url',
+                           'confirm']
+
+    def _data_for_gitlab(self, extra_parameters={}):
+        if hasattr(self, 'confirm'):
+            self.confirm = str(self.confirm).lower()
+        return super(User, self)._data_for_gitlab(extra_parameters)
 
     def Key(self, id=None, **kwargs):
         return UserKey._get_list_or_object(self.gitlab, id,


### PR DESCRIPTION
GitLab add 'confirm' field support to its API since 7.9.0. However, it takes `'false'` string only when the content type of request is set to 'application/json'. So I just add `confirm` to `optionalCreateAttrs` list and override `_data_for_gitlab` to make sure `confirm` is converted to boolean string.

It has been tested on GitLab HQ 7.14.3 and API is v3.

Additional info: <https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/1281>