### PR TITLE
Use name as sort key to fix Python 3 TypeError

### DIFF
--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -21,6 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 import argparse
 import inspect
+import operator
 import re
 import sys
 
@@ -256,7 +257,7 @@ def main():
                 classes.append(cls)
         except AttributeError:
             pass
-    classes.sort()
+    classes.sort(key=operator.attrgetter("__name__"))
 
     for cls in classes:
         arg_name = clsToWhat(cls)


### PR DESCRIPTION
Sort types explicitly by name to fix unorderable types TypeError in
Python 3.

The call to sort() on cli.py line 259 produced the error:

    TypeError: unorderable types: type() < type()