### PR TITLE
Check for action arg before use (fix Python 3 error)

### DIFF
--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -271,7 +271,14 @@ def main():
     config_files = arg.config_file
     gitlab_id = arg.gitlab
     verbose = arg.verbose
-    action = arg.action
+
+    if hasattr(arg, "action"):
+        action = arg.action
+    else:
+        sys.stderr.write("error: an action is required\n\n")
+        parser.print_help()
+        sys.exit(1)
+
     what = arg.what
 
     # Remove CLI behavior-related args


### PR DESCRIPTION
Check that the parsed `action` attribute exists before using it.
Previously, whenever the command-line tool was invoked on Python 3.4
without a bare-word argument, which is expected to be the action, the
program aborts with an AttributeError in cli.py on the line assigning
`arg.action` to `action`:

    AttributeError: 'Namespace' object has no attribute 'action'