### PR TITLE
fix GitlabObject creation in _custom_list

### DIFF
--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -163,7 +163,7 @@ class BaseManager(object):
 
         l = []
         for j in r.json():
-            o = cls(self, j)
+            o = cls(self.gitlab, j)
             o._from_api = True
             l.append(o)
 


### PR DESCRIPTION
call GitlabObject.__init__(self, gl, ...)
with self.gitlab(gitlab.Gitlab) instread self(BaseManager)
