### PR TITLE
Add support for searching for users and getting a user by username

### DIFF
--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -565,6 +565,14 @@ class User(GitlabObject):
 class UserManager(BaseManager):
     obj_cls = User
 
+    def search(self, query, **kwargs):
+        """Search users.
+
+        Returns a list of matching users.
+        """
+        url = self.obj_cls._url + '?search=' + query
+        return self._custom_list(url, self.obj_cls, **kwargs)
+
 
 class CurrentUserKey(GitlabObject):
     _url = '/user/keys'

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -491,6 +491,14 @@ class GitlabObject(object):
         return {k: v for k, v in six.iteritems(self.__dict__)
                 if (not isinstance(v, BaseManager) and not k[0] == '_')}
 
+    def __eq__(self, other):
+        if type(other) is type(self):
+            return self.as_dict() == other.as_dict()
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
 
 class UserKey(GitlabObject):
     _url = '/users/%(user_id)s/keys'
@@ -543,6 +551,15 @@ class User(GitlabObject):
         r = self.gitlab._raw_put(url, **kwargs)
         raise_error_from_response(r, GitlabUnblockError)
         self.state = 'active'
+
+    def __eq__(self, other):
+        if type(other) is type(self):
+            selfdict = self.as_dict()
+            otherdict = other.as_dict()
+            selfdict.pop(u'password', None)
+            otherdict.pop(u'password', None)
+            return selfdict == otherdict
+        return False
 
 
 class UserManager(BaseManager):

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -34,9 +34,7 @@ from gitlab.exceptions import *  # noqa
 class jsonEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, GitlabObject):
-            return {k: v for k, v in six.iteritems(obj.__dict__)
-                    if (not isinstance(v, BaseManager)
-                        and not k[0] == '_')}
+            return obj.as_dict()
         elif isinstance(obj, gitlab.Gitlab):
             return {'url': obj._url}
         return json.JSONEncoder.default(self, obj)
@@ -487,6 +485,11 @@ class GitlabObject(object):
             str: The json string.
         """
         return json.dumps(self, cls=jsonEncoder)
+
+    def as_dict(self):
+        """Dump the object as a dict."""
+        return {k: v for k, v in six.iteritems(self.__dict__)
+                if (not isinstance(v, BaseManager) and not k[0] == '_')}
 
 
 class UserKey(GitlabObject):

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -573,6 +573,20 @@ class UserManager(BaseManager):
         url = self.obj_cls._url + '?search=' + query
         return self._custom_list(url, self.obj_cls, **kwargs)
 
+    def get_by_username(self, username, **kwargs):
+        """Get a user by its username.
+
+        Returns a User object or None if the named user does not
+        exist.
+        """
+        url = self.obj_cls._url + '?username=' + username
+        results = self._custom_list(url, self.obj_cls, **kwargs)
+        assert len(results) in (0, 1)
+        try:
+            return results[0]
+        except IndexError:
+            raise GitlabGetError('no such user: ' + username)
+
 
 class CurrentUserKey(GitlabObject):
     _url = '/user/keys'

--- a/gitlab/tests/test_manager.py
+++ b/gitlab/tests/test_manager.py
@@ -235,6 +235,29 @@ class TestGitlabManager(unittest.TestCase):
             self.assertEqual(data[0].id, 1)
             self.assertEqual(data[1].id, 2)
 
+    def test_user_manager_search(self):
+        mgr = UserManager(self.gitlab)
+
+        @urlmatch(scheme="http", netloc="localhost", path="/api/v3/users",
+                  query="search=foo", method="get")
+        def resp_get_search(url, request):
+            headers = {'content-type': 'application/json'}
+            content = ('[{"name": "foo1", "id": 1}, '
+                       '{"name": "foo2", "id": 2}]')
+            content = content.encode("utf-8")
+            return response(200, content, headers, None, 5, request)
+
+        with HTTMock(resp_get_search):
+            data = mgr.search('foo')
+            self.assertEqual(type(data), list)
+            self.assertEqual(2, len(data))
+            self.assertEqual(type(data[0]), User)
+            self.assertEqual(type(data[1]), User)
+            self.assertEqual(data[0].name, "foo1")
+            self.assertEqual(data[1].name, "foo2")
+            self.assertEqual(data[0].id, 1)
+            self.assertEqual(data[1].id, 2)
+
     def test_group_manager_search(self):
         mgr = GroupManager(self.gitlab)
 

--- a/tools/python_test.py
+++ b/tools/python_test.py
@@ -54,6 +54,15 @@ actual = sorted(gl.users.search('foo'), cmp=usercmp)
 assert expected == actual
 assert gl.users.search('asdf') == []
 
+assert gl.users.get_by_username('foobar') == foobar_user
+assert gl.users.get_by_username('foo') == new_user
+try:
+    gl.users.get_by_username('asdf')
+except gitlab.GitlabGetError:
+    pass
+else:
+    assert False
+
 # SSH keys
 key = new_user.keys.create({'title': 'testkey', 'key': SSH_KEY})
 assert(len(new_user.keys.list()) == 1)

--- a/tools/python_test.py
+++ b/tools/python_test.py
@@ -43,12 +43,24 @@ assert(new_user.email == user.email)
 new_user.block()
 new_user.unblock()
 
+foobar_user = gl.users.create(
+    {'email': 'foobar@example.com', 'username': 'foobar',
+     'name': 'Foo Bar', 'password': 'foobar_password'})
+
+assert gl.users.search('foobar') == [foobar_user]
+usercmp = lambda x,y: cmp(x.id, y.id)
+expected = sorted([new_user, foobar_user], cmp=usercmp)
+actual = sorted(gl.users.search('foo'), cmp=usercmp)
+assert expected == actual
+assert gl.users.search('asdf') == []
+
 # SSH keys
 key = new_user.keys.create({'title': 'testkey', 'key': SSH_KEY})
 assert(len(new_user.keys.list()) == 1)
 key.delete()
 
 new_user.delete()
+foobar_user.delete()
 assert(len(gl.users.list()) == 1)
 
 # current user key


### PR DESCRIPTION
Add support for `/users?search=foo` and `/users?username=foo`.

Also, in order to make it easier to write tests for these new features, add:
  * `GitlabObject.as_dict()`, which is the same as calling `json.loads()` on the output of `GitlabObject.json()`
  * `GitlabObject.__eq__()` and `GitlabObject.__ne__()`, which checks the dictionaries returned by `GitlabObject.as_dict()` for equivalence