### PR TITLE
Fix the 'invalid syntax' on Python 3.2, because of u'password'

### DIFF
--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -543,8 +543,8 @@ class User(GitlabObject):
         if type(other) is type(self):
             selfdict = self.as_dict()
             otherdict = other.as_dict()
-            selfdict.pop(u'password', None)
-            otherdict.pop(u'password', None)
+            selfdict.pop('password', None)
+            otherdict.pop('password', None)
             return selfdict == otherdict
         return False
 


### PR DESCRIPTION
More informations regarding this issue:

Operating system: Debian Wheezy, with Python 3.2 and the last
version of python-gitlab.

The gitlab module raised this exception, because of the 'u' (Unicode):

Traceback (most recent call last):
  File "push_settings.py", line 14, in <module>
    from helper import ROOT_EMAIL, ADMINS, git, old_git
  File "/opt/scripts/gitlab/helpers/helper.py", line 25, in <module>
    from gitlab import Gitlab
  File "/opt/scripts/gitlab/helpers/gitlab/__init__.py", line 32, in <module>
    from gitlab.objects import *  # noqa
  File "/opt/scripts/gitlab/helpers/gitlab/objects.py", line 546
    selfdict.pop(u'password', None)
			   ^
SyntaxError: invalid syntax
It is a recent change:
01802c0 (Richard Hansen 2016-02-11 22:43:25 -0500 546) selfdict.pop(u'password', None)
01802c0 (Richard Hansen 2016-02-11 22:43:25 -0500 547) otherdict.pop(u'password', None)

To solve the issue, 'u' was removed.