### PR TITLE
Wrong create attributes check in update.

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -568,7 +568,7 @@ class Gitlab(object):
         params.update(kwargs)
         missing = []
         for k in itertools.chain(obj.requiredUrlAttrs,
-                                 obj.requiredCreateAttrs):
+                                 obj.requiredUpdateAttrs):
             if k not in params:
                 missing.append(k)
         if missing:


### PR DESCRIPTION
There are new requiredUpdateAttrs in GitlabObject, I guess you want to use it in Gitlab.update instead of requiredCreateAttrs.
Right now with requiredCreateAttrs for user ['email', 'username', 'name', 'password'], one cannot update user without updating password.