### PR TITLE
Remove 'next_url' from kwargs before passing it to the cls constructor.

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -281,7 +281,7 @@ class Gitlab(object):
         get_all_results = kwargs.get('all', False)
 
         # Remove parameters from kwargs before passing it to constructor
-        for key in ['all', 'page', 'per_page', 'sudo']:
+        for key in ['all', 'page', 'per_page', 'sudo', 'next_url']:
             if key in cls_kwargs:
                 del cls_kwargs[key]
 
@@ -385,7 +385,7 @@ class Gitlab(object):
         get_all_results = params.get('all', False)
 
         # Remove parameters from kwargs before passing it to constructor
-        for key in ['all', 'page', 'per_page', 'sudo']:
+        for key in ['all', 'page', 'per_page', 'sudo', 'next_url']:
             if key in cls_kwargs:
                 del cls_kwargs[key]
 


### PR DESCRIPTION
I had troubles iterating through all projects and changing some settings. The save method failed and I figured out that the 'next_url' attribute is still set and used in the _construct_url method.

This is an attempt to fix this, I might have missed something ...