### PR TITLE
Enable updates on ProjectIssueNotes

### DIFF
--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -935,7 +935,7 @@ class ProjectHookManager(BaseManager):
 class ProjectIssueNote(GitlabObject):
     _url = '/projects/%(project_id)s/issues/%(issue_id)s/notes'
     _constructorTypes = {'author': 'User'}
-    canUpdate = False
+    canUpdate = True
     canDelete = False
     requiredUrlAttrs = ['project_id', 'issue_id']
     requiredCreateAttrs = ['body']

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -935,7 +935,6 @@ class ProjectHookManager(BaseManager):
 class ProjectIssueNote(GitlabObject):
     _url = '/projects/%(project_id)s/issues/%(issue_id)s/notes'
     _constructorTypes = {'author': 'User'}
-    canUpdate = True
     canDelete = False
     requiredUrlAttrs = ['project_id', 'issue_id']
     requiredCreateAttrs = ['body']


### PR DESCRIPTION
According to the [GitLab API Docs][1] Issue comments can be updated by api calls. This very minor change enables this in python-gitlab

This is useful to me and perhaps others for things like annotating comments with references to external issue trackers not supported in GitLab already. This change would allow notes on issues to be modified and saved, for example:

```python
import os
from gitlab import Gitlab
gl = Gitlab(os.environ['GITLAB_HOST'], os.environ['GITLAB_TOKEN'])
note = gl.project.get('adamreid/test').issues.get(1).notes.get(1)
note.body = note.body.replace('issue:1234','issue:[1234](http://issues.example.com/issue/1234)')
note.save()
```
[1]:http://doc.gitlab.com/ce/api/notes.html#modify-existing-issue-note