### PR TITLE
Fix: --title is required argument, when in reality optional

### DIFF
--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -1226,6 +1226,7 @@ class ProjectMilestone(GitlabObject):
     requiredUrlAttrs = ['project_id']
     requiredCreateAttrs = ['title']
     optionalCreateAttrs = ['description', 'due_date', 'state_event']
+    optionalUpdateAttrs = requiredCreateAttrs + optionalCreateAttrs
     shortPrintAttr = 'title'
 
     def issues(self):


### PR DESCRIPTION
I add one line that includes "title" to be an optional command line argument.