### PR TITLE
mention per_page in users.py

### DIFF
--- a/docs/gl_objects/users.py
+++ b/docs/gl_objects/users.py
@@ -1,5 +1,5 @@
 # list
-users = gl.users.list()
+users = gl.users.list(all=True)
 # end list
 
 # search


### PR DESCRIPTION
I can't seem to find any reference on the `all` and `per_page` argument, thus it took me a long time to finally know how to list all gitlab users using `gitlab.users.list`

however I'm not sure this is the right way to solve this, perhaps add docs to `gitlab.users.list`? or change the default value for `per_page`? tell me and I'll be happy to contribute.