### PR TITLE
JIRA service - add api_url to optional attributes

### DIFF
--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -1788,7 +1788,7 @@ class ProjectService(GitlabObject):
         'irker': (('recipients', ), ('default_irc_uri', 'server_port',
                                      'server_host', 'colorize_messages')),
         'jira': (('new_issue_url', 'project_url', 'issues_url'),
-                 ('description', 'username', 'password')),
+                 ('api_url', 'description', 'username', 'password')),
         'pivotaltracker': (('token', ), tuple()),
         'pushover': (('api_key', 'user_key', 'priority'), ('device', 'sound')),
         'redmine': (('new_issue_url', 'project_url', 'issues_url'),


### PR DESCRIPTION
The api_url attribute is mandatory at least since GitLab 8.11. Otherwise
server returns gitlab.exceptions.GitlabUpdateError: 400: 400 (Bad request) "api_url" not given.

Keeps the parameter as optional to maintain backward compatibility with older GitLab
versions. 
