### PR TITLE
Missing coma concatenates array values

### DIFF
--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -689,7 +689,7 @@ class ApplicationSettings(GitlabObject):
                            'domain_blacklist',
                            'domain_blacklist_enabled',
                            'domain_whitelist',
-                           'enabled_git_access_protocol'
+                           'enabled_git_access_protocol',
                            'gravatar_enabled',
                            'home_page_url',
                            'max_attachment_size',


### PR DESCRIPTION
'enabled_git_access_protocolgravatar_enabled' were two distinct values in ApplicationSettings.optionalUpdateAttrs.