### PR TITLE
Add ProjectBuild.erase()

### DIFF
--- a/docs/gl_objects/builds.py
+++ b/docs/gl_objects/builds.py
@@ -103,10 +103,6 @@ build.cancel()
 build.retry()
 # end retry
 
-# delete
-gl.project_builds.delete(build_id, project_id=1)
-# or
-project.builds.delete(build_id)
-# or
-build.delete()
-# end delete
+# erase
+build.erase()
+# end erase

--- a/docs/gl_objects/builds.rst
+++ b/docs/gl_objects/builds.rst
@@ -150,8 +150,8 @@ Cancel/retry a build:
    :start-after: # retry
    :end-before: # end retry
 
-Erase a build:
+Erase a build (artifacts and trace):
 
 .. literalinclude:: builds.py
-   :start-after: # delete
-   :end-before: # end delete
+   :start-after: # erase
+   :end-before: # end erase

--- a/gitlab/exceptions.py
+++ b/gitlab/exceptions.py
@@ -95,6 +95,10 @@ class GitlabBuildRetryError(GitlabRetryError):
     pass
 
 
+class GitlabBuildEraseError(GitlabRetryError):
+    pass
+
+
 class GitlabPipelineRetryError(GitlabRetryError):
     pass
 

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -961,6 +961,12 @@ class ProjectBuild(GitlabObject):
         r = self.gitlab._raw_post(url)
         raise_error_from_response(r, GitlabBuildRetryError, 201)
 
+    def erase(self, **kwargs):
+        """Erase the build (remove build artifacts and trace)."""
+        url = '/projects/%s/builds/%s/erase' % (self.project_id, self.id)
+        r = self.gitlab._raw_post(url)
+        raise_error_from_response(r, GitlabBuildEraseError, 201)
+
     def keep_artifacts(self, **kwargs):
         """Prevent artifacts from being delete when expiration is set.
 


### PR DESCRIPTION
This adds `ProjectBuild.erase()`.

We can't use the existing delete() functionality, because GitLab uses
`POST /projects/:id/builds/:build_id/erase` to erase a build. Instead of
overriding delete(), we add a separate erase() method to keep the naming
consistent, and allow potentially more fine-grained operations in the
future.

- https://docs.gitlab.com/ce/api/builds.html#erase-a-build

This fixes #158