### PR TITLE
Fix ProjectBuild.play raising error even on success

### DIFF
--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -965,7 +965,7 @@ class ProjectBuild(GitlabObject):
         """Trigger a build explicitly."""
         url = '/projects/%s/builds/%s/play' % (self.project_id, self.id)
         r = self.gitlab._raw_post(url)
-        raise_error_from_response(r, GitlabBuildPlayError, 201)
+        raise_error_from_response(r, GitlabBuildPlayError)
 
     def erase(self, **kwargs):
         """Erase the build (remove build artifacts and trace)."""


### PR DESCRIPTION
Running play on ProjectBuild raises a GitlabBuildPlayError although the request was successful. It looks like gitlab returns a 200-OK instead of 201-CREATED response and as such always raises an exception.