### PR TITLE
Pass kwargs to object factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ MANIFEST
 .idea/
 docs/_build
 .testrepository/
+.tox

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -280,13 +280,14 @@ class GitlabObject(object):
 
             raise GitlabGetError("Object not found")
 
-    def _get_object(self, k, v):
+    def _get_object(self, k, v, **kwargs):
         if self._constructorTypes and k in self._constructorTypes:
-            return globals()[self._constructorTypes[k]](self.gitlab, v)
+            return globals()[self._constructorTypes[k]](self.gitlab, v,
+                                                        **kwargs)
         else:
             return v
 
-    def _set_from_dict(self, data):
+    def _set_from_dict(self, data, **kwargs):
         if not hasattr(data, 'items'):
             return
 
@@ -294,11 +295,11 @@ class GitlabObject(object):
             if isinstance(v, list):
                 self.__dict__[k] = []
                 for i in v:
-                    self.__dict__[k].append(self._get_object(k, i))
+                    self.__dict__[k].append(self._get_object(k, i, **kwargs))
             elif v is None:
                 self.__dict__[k] = None
             else:
-                self.__dict__[k] = self._get_object(k, v)
+                self.__dict__[k] = self._get_object(k, v, **kwargs)
 
     def _create(self, **kwargs):
         if not self.canCreate:
@@ -377,7 +378,7 @@ class GitlabObject(object):
             data = self.gitlab.get(self.__class__, data, **kwargs)
             self._from_api = True
 
-        self._set_from_dict(data)
+        self._set_from_dict(data, **kwargs)
 
         if kwargs:
             for k, v in kwargs.items():


### PR DESCRIPTION
### The Issue
When you fetch tags from a project and try to access the builds through a tag commit object like in the following snippet:
```
client = gitlab.Gitlab(..)
project = client.projects.get('some-id')
tag = project.tags.list()[0]
tag.commit.builds()
```
… then python-gitlab raises an AttributeError in line 1128 in objects.py. This happens because it tries to construct the request url and cannot find `self.project_id`.
```
url = '/projects/%s/repository/commits/%s/builds' % (self.project_id, self.id)
```
### What Causes the Issue?
When you fetch tags python-gitlab constructs Tag-objects which call `_set_from_dict` internally. Then this method checks if it contains data for subobjects and calls subsequently `_get_object` . At this point the subobjects will be created from the gitlab response data but do not receive any "kwargs" information and as such are missing the project-id.

### Possible Solution
I simply passed down the kwargs to `_get_object`. It solves the specific issue although I am not exactly sure if this is the best way to go. Additionally I am not a huge fan of passing down parameters for too many levels as it feels conceptually wrong.