### PR TITLE
Feature: enable / disable the deploy key in a project

### DIFF
--- a/docs/gl_objects/deploy_keys.py
+++ b/docs/gl_objects/deploy_keys.py
@@ -34,3 +34,15 @@ key = project.keys.list(key_id)
 # or
 key.delete()
 # end delete
+
+# enable
+key = gl.project_keys.enable(key_id, project_id=1)
+# or
+key = project.keys.enable(key_id)
+# end enable
+
+# disable
+key = gl.project_keys.disable(key_id, project_id=1)
+# or
+key = project.keys.disable(key_id)
+# end disable

--- a/docs/gl_objects/deploy_keys.py
+++ b/docs/gl_objects/deploy_keys.py
@@ -36,13 +36,9 @@ key.delete()
 # end delete
 
 # enable
-key = gl.project_keys.enable(key_id, project_id=1)
-# or
 key = project.keys.enable(key_id)
 # end enable
 
 # disable
-key = gl.project_keys.disable(key_id, project_id=1)
-# or
 key = project.keys.disable(key_id)
 # end disable

--- a/docs/gl_objects/deploy_keys.rst
+++ b/docs/gl_objects/deploy_keys.rst
@@ -56,3 +56,15 @@ Delete a deploy key for a project:
 .. literalinclude:: deploy_keys.py
    :start-after: # delete
    :end-before: # end delete
+
+Enable a deploy key for a project:
+
+.. literalinclude:: deploy_keys.py
+   :start-after: # enable
+   :end-before: # end enable
+
+Disable a deploy key for a project:
+
+.. literalinclude:: deploy_keys.py
+   :start-after: # disable
+   :end-before: # end disable

--- a/gitlab/exceptions.py
+++ b/gitlab/exceptions.py
@@ -75,6 +75,10 @@ class GitlabTransferProjectError(GitlabOperationError):
     pass
 
 
+class GitlabProjectDeployKeyError(GitlabOperationError):
+    pass
+
+
 class GitlabCancelError(GitlabOperationError):
     pass
 

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -1249,21 +1249,21 @@ class ProjectKey(GitlabObject):
     requiredUrlAttrs = ['project_id']
     requiredCreateAttrs = ['title', 'key']
 
-    def enable(self, key_id):
-        """Enable a deploy key for a project."""
-        url = '/projects/%s/deploy_keys/%s/enable' % (self.project_id, key_id)
-        r = self.gitlab._raw_post(url)
-        raise_error_from_response(r, GitlabProjectDeployKeyError, 200)
-
-    def disable(self, key_id):
-        """Disable a deploy key for a project."""
-        url = '/projects/%s/deploy_keys/%s/disable' % (self.project_id, key_id)
-        r = self.gitlab._raw_delete(url)
-        raise_error_from_response(r, GitlabProjectDeployKeyError, 200)
-
 
 class ProjectKeyManager(BaseManager):
     obj_cls = ProjectKey
+
+    def enable(self, key_id):
+        """Enable a deploy key for a project."""
+        url = '/projects/%s/deploy_keys/%s/enable' % (self.parent.id, key_id)
+        r = self.gitlab._raw_post(url)
+        raise_error_from_response(r, GitlabProjectDeployKeyError, 201)
+
+    def disable(self, key_id):
+        """Disable a deploy key for a project."""
+        url = '/projects/%s/deploy_keys/%s/disable' % (self.parent.id, key_id)
+        r = self.gitlab._raw_delete(url)
+        raise_error_from_response(r, GitlabProjectDeployKeyError, 201)
 
 
 class ProjectEvent(GitlabObject):

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -1249,21 +1249,21 @@ class ProjectKey(GitlabObject):
     requiredUrlAttrs = ['project_id']
     requiredCreateAttrs = ['title', 'key']
 
-
-class ProjectKeyManager(BaseManager):
-    obj_cls = ProjectKey
-
     def enable_deploy_key(self, project_id, key_id):
-        """Enable a deploy key in a project."""
+        """Enable a deploy key for a project."""
         url = '/projects/%s/deploy_keys/%s/enable' % (project_id, key_id)
         r = self.gitlab._raw_post(url)
         raise_error_from_response(r, GitlabBuildRetryError, 201)
 
     def disable_deploy_key(self, project_id, key_id):
-        """Disable a deploy key in a project."""
+        """Disable a deploy key for a project."""
         url = '/projects/%s/deploy_keys/%s/disable' % (project_id, key_id)
         r = self.gitlab._raw_delete(url)
         raise_error_from_response(r, GitlabBuildRetryError, 201)
+
+
+class ProjectKeyManager(BaseManager):
+    obj_cls = ProjectKey
 
 
 class ProjectEvent(GitlabObject):

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -1253,13 +1253,13 @@ class ProjectKey(GitlabObject):
         """Enable a deploy key for a project."""
         url = '/projects/%s/deploy_keys/%s/enable' % (project_id, key_id)
         r = self.gitlab._raw_post(url)
-        raise_error_from_response(r, GitlabBuildRetryError, 201)
+        raise_error_from_response(r, GitlabProjectDeployKeyError, 201)
 
     def disable_deploy_key(self, project_id, key_id):
         """Disable a deploy key for a project."""
         url = '/projects/%s/deploy_keys/%s/disable' % (project_id, key_id)
         r = self.gitlab._raw_delete(url)
-        raise_error_from_response(r, GitlabBuildRetryError, 201)
+        raise_error_from_response(r, GitlabProjectDeployKeyError, 201)
 
 
 class ProjectKeyManager(BaseManager):

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -1253,6 +1253,18 @@ class ProjectKey(GitlabObject):
 class ProjectKeyManager(BaseManager):
     obj_cls = ProjectKey
 
+    def enable_deploy_key(self, project_id, key_id):
+        """Enable a deploy key in a project."""
+        url = '/projects/%s/deploy_keys/%s/enable' % (project_id, key_id)
+        r = self.gitlab._raw_post(url)
+        raise_error_from_response(r, GitlabBuildRetryError, 201)
+
+    def disable_deploy_key(self, project_id, key_id):
+        """Disable a deploy key in a project."""
+        url = '/projects/%s/deploy_keys/%s/disable' % (project_id, key_id)
+        r = self.gitlab._raw_post(url)
+        raise_error_from_response(r, GitlabBuildRetryError, 201)
+
 
 class ProjectEvent(GitlabObject):
     _url = '/projects/%(project_id)s/events'

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -1262,7 +1262,7 @@ class ProjectKeyManager(BaseManager):
     def disable_deploy_key(self, project_id, key_id):
         """Disable a deploy key in a project."""
         url = '/projects/%s/deploy_keys/%s/disable' % (project_id, key_id)
-        r = self.gitlab._raw_post(url)
+        r = self.gitlab._raw_delete(url)
         raise_error_from_response(r, GitlabBuildRetryError, 201)
 
 

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -1249,13 +1249,13 @@ class ProjectKey(GitlabObject):
     requiredUrlAttrs = ['project_id']
     requiredCreateAttrs = ['title', 'key']
 
-    def enable_deploy_key(self, project_id, key_id):
+    def enable(self, key_id, project_id):
         """Enable a deploy key for a project."""
         url = '/projects/%s/deploy_keys/%s/enable' % (project_id, key_id)
         r = self.gitlab._raw_post(url)
         raise_error_from_response(r, GitlabProjectDeployKeyError, 201)
 
-    def disable_deploy_key(self, project_id, key_id):
+    def disable(self, key_id, project_id):
         """Disable a deploy key for a project."""
         url = '/projects/%s/deploy_keys/%s/disable' % (project_id, key_id)
         r = self.gitlab._raw_delete(url)

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -1249,17 +1249,17 @@ class ProjectKey(GitlabObject):
     requiredUrlAttrs = ['project_id']
     requiredCreateAttrs = ['title', 'key']
 
-    def enable(self, key_id, project_id):
+    def enable(self, key_id):
         """Enable a deploy key for a project."""
-        url = '/projects/%s/deploy_keys/%s/enable' % (project_id, key_id)
+        url = '/projects/%s/deploy_keys/%s/enable' % (self.project_id, key_id)
         r = self.gitlab._raw_post(url)
-        raise_error_from_response(r, GitlabProjectDeployKeyError, 201)
+        raise_error_from_response(r, GitlabProjectDeployKeyError, 200)
 
-    def disable(self, key_id, project_id):
+    def disable(self, key_id):
         """Disable a deploy key for a project."""
-        url = '/projects/%s/deploy_keys/%s/disable' % (project_id, key_id)
+        url = '/projects/%s/deploy_keys/%s/disable' % (self.project_id, key_id)
         r = self.gitlab._raw_delete(url)
-        raise_error_from_response(r, GitlabProjectDeployKeyError, 201)
+        raise_error_from_response(r, GitlabProjectDeployKeyError, 200)
 
 
 class ProjectKeyManager(BaseManager):


### PR DESCRIPTION
To solve the issue https://github.com/gpocentek/python-gitlab/issues/179 I added 2 new features to the class ProjectKeyManager: enable_deploy_key() and disable_deploy_key() .
