### PR TITLE
Fix `should_remove_source_branch`

### DIFF
--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -1732,9 +1732,9 @@ class ProjectMergeRequest(GitlabObject):
         if merge_commit_message:
             data['merge_commit_message'] = merge_commit_message
         if should_remove_source_branch:
-            data['should_remove_source_branch'] = 'should_remove_source_branch'
+            data['should_remove_source_branch'] = True
         if merged_when_build_succeeds:
-            data['merged_when_build_succeeds'] = 'merged_when_build_succeeds'
+            data['merged_when_build_succeeds'] = True
 
         r = self.gitlab._raw_put(url, data=data, **kwargs)
         errors = {401: GitlabMRForbiddenError,


### PR DESCRIPTION
I'm getting the following 400 error when using `merge`:

```
  File "/usr/local/lib/python2.7/site-packages/gitlab/objects.py", line 1533, in merge
    raise_error_from_response(r, errors)
  File "/usr/local/lib/python2.7/site-packages/gitlab/exceptions.py", line 168, in raise_error_from_response
    response_body=response.content)
gitlab.exceptions.GitlabOperationError: 400: {"error":"should_remove_source_branch is invalid"}
```

It seems like Gitlab has changed their validations - using `True` seems to work.