### PR TITLE
Fix JIRA service editing for GitLab 8.14+

### DIFF
--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -1992,8 +1992,16 @@ class ProjectService(GitlabObject):
                                   'server')),
         'irker': (('recipients', ), ('default_irc_uri', 'server_port',
                                      'server_host', 'colorize_messages')),
-        'jira': (('new_issue_url', 'project_url', 'issues_url'),
-                 ('api_url', 'description', 'username', 'password')),
+        'jira': (tuple(), (
+                 # Required fields in GitLab >= 8.14
+                 'url', 'project_key',
+
+                 # Required fields in GitLab < 8.14
+                 'new_issue_url', 'project_url', 'issues_url', 'api_url',
+                 'description',
+
+                 # Optional fields
+                 'username', 'password')),
         'pivotaltracker': (('token', ), tuple()),
         'pushover': (('api_key', 'user_key', 'priority'), ('device', 'sound')),
         'redmine': (('new_issue_url', 'project_url', 'issues_url'),

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -2001,7 +2001,7 @@ class ProjectService(GitlabObject):
                  'description',
 
                  # Optional fields
-                 'username', 'password')),
+                 'username', 'password', 'jira_issue_transition_id')),
         'pivotaltracker': (('token', ), tuple()),
         'pushover': (('api_key', 'user_key', 'priority'), ('device', 'sound')),
         'redmine': (('new_issue_url', 'project_url', 'issues_url'),


### PR DESCRIPTION
GitLab simplified the configuration for JIRA service and renamed most of
the fields. To maintain backward compatibility all mandatory fields were
moved to optional section. 

See: https://docs.gitlab.com/ce/api/services.html#jira

**Example of exception it fixes**:
`gitlab.exceptions.GitlabUpdateError: 400: 400 (Bad request) "url" not given`
