### PR TITLE
Provide API wrapper for cherry picking commits

### DIFF
--- a/docs/gl_objects/commits.py
+++ b/docs/gl_objects/commits.py
@@ -39,6 +39,10 @@ commit = project.commits.get('e3d5a71b')
 diff = commit.diff()
 # end diff
 
+# cherry
+commit.cherry_pick(branch='target_branch')
+# end cherry
+
 # comments list
 comments = gl.project_commit_comments.list(project_id=1, commit_id='master')
 # or

--- a/docs/gl_objects/commits.rst
+++ b/docs/gl_objects/commits.rst
@@ -43,7 +43,7 @@ Get the diff for a commit:
    :start-after: # diff
    :end-before: # end diff
 
-Cherry-pick a commit into another branch
+Cherry-pick a commit into another branch:
 
 .. literalinclude:: commits.py
    :start-after: # cherry

--- a/docs/gl_objects/commits.rst
+++ b/docs/gl_objects/commits.rst
@@ -43,6 +43,12 @@ Get the diff for a commit:
    :start-after: # diff
    :end-before: # end diff
 
+Cherry-pick a commit into another branch
+
+.. literalinclude:: commits.py
+   :start-after: # cherry
+   :end-before: # end cherry
+
 Commit comments
 ===============
 

--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -42,7 +42,9 @@ EXTRA_ACTIONS = {
     gitlab.ProjectCommit: {'diff': {'required': ['id', 'project-id']},
                            'blob': {'required': ['id', 'project-id',
                                                  'filepath']},
-                           'builds': {'required': ['id', 'project-id']}},
+                           'builds': {'required': ['id', 'project-id']},
+                           'cherrypick': {'required': ['id', 'project-id',
+                                                       'branch']}},
     gitlab.ProjectIssue: {'subscribe': {'required': ['id', 'project-id']},
                           'unsubscribe': {'required': ['id', 'project-id']},
                           'move': {'required': ['id', 'project-id',
@@ -266,6 +268,13 @@ class GitlabCLI(object):
             return o.builds()
         except Exception as e:
             _die("Impossible to get commit builds", e)
+
+    def do_project_commit_cherrypick(self, cls, gl, what, args):
+        try:
+            o = self.do_get(cls, gl, what, args)
+            o.cherry_pick(branch=args['branch'])
+        except Exception as e:
+            _die("Impossible to cherry-pick commit", e)
 
     def do_project_build_cancel(self, cls, gl, what, args):
         try:

--- a/gitlab/exceptions.py
+++ b/gitlab/exceptions.py
@@ -146,6 +146,9 @@ class GitlabTodoError(GitlabOperationError):
 class GitlabTimeTrackingError(GitlabOperationError):
     pass
 
+class GitlabCherryPickError(GitlabOperationError):
+    pass
+
 
 def raise_error_from_response(response, error, expected_code=200):
     """Tries to parse gitlab error message from response and raises error.

--- a/gitlab/exceptions.py
+++ b/gitlab/exceptions.py
@@ -146,6 +146,7 @@ class GitlabTodoError(GitlabOperationError):
 class GitlabTimeTrackingError(GitlabOperationError):
     pass
 
+
 class GitlabCherryPickError(GitlabOperationError):
     pass
 

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -1137,7 +1137,7 @@ class ProjectBranch(GitlabObject):
     requiredCreateAttrs = ['branch_name', 'ref']
 
     def protect(self, protect=True, **kwargs):
-        """Protects the project."""
+        """Protects the branch."""
         url = self._url % {'project_id': self.project_id}
         action = 'protect' if protect else 'unprotect'
         url = "%s/%s/%s" % (url, self.name, action)
@@ -1150,7 +1150,7 @@ class ProjectBranch(GitlabObject):
             del self.protected
 
     def unprotect(self, **kwargs):
-        """Unprotects the project."""
+        """Unprotects the branch."""
         self.protect(False, **kwargs)
 
 

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -1362,8 +1362,8 @@ class ProjectCommit(GitlabObject):
         Raises:
             GitlabCherryPickError: If the cherry pick could not be applied.
         """
-        pid = self.project_id
-        url = '/projects/%s/repository/commits/%s/cherry_pick' % (pid, self.id)
+        url = ('/projects/%s/repository/commits/%s/cherry_pick' %
+               (self.project_id, self.id))
 
         r = self.gitlab._raw_post(url, data={'project_id': self.project_id,
                                              'branch': branch}, **kwargs)

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -1362,8 +1362,8 @@ class ProjectCommit(GitlabObject):
         Raises:
             GitlabCherryPickError: If the cherry pick could not be applied.
         """
-        url = '/projects/{0:s}/repository/commits/{1:s}/cherry_pick'.format(
-            self.project_id, self.id)
+        pid = self.project_id
+        url = '/projects/%s/repository/commits/%s/cherry_pick' % (pid, self.id)
 
         r = self.gitlab._raw_post(url, data={'project_id': self.project_id,
                                              'branch': branch}, **kwargs)

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -1353,7 +1353,7 @@ class ProjectCommit(GitlabObject):
                                      {'project_id': self.project_id},
                                      **kwargs)
 
-    def cherry_pick(self,branch,**kwargs):
+    def cherry_pick(self, branch, **kwargs):
         """Cherry-pick a commit into a branch.
 
         Args:
@@ -1364,9 +1364,12 @@ class ProjectCommit(GitlabObject):
         """
         url = '/projects/%s/repository/commits/%s/cherry_pick' % (self.project_id,
                                                                   self.id)
-        r = self.gitlab._raw_post(url, data={'project_id':self.project_id,'branch': branch}, **kwargs)
+
+        r = self.gitlab._raw_post(url, data={'project_id': self.project_id,
+                                             'branch': branch}, **kwargs)
         errors = {400: GitlabCherryPickError}
-        raise_error_from_response(r, errors,expected_code=201)
+        raise_error_from_response(r, errors, expected_code=201)
+
 
 class ProjectCommitManager(BaseManager):
     obj_cls = ProjectCommit

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -1362,8 +1362,8 @@ class ProjectCommit(GitlabObject):
         Raises:
             GitlabCherryPickError: If the cherry pick could not be applied.
         """
-        url = '/projects/%s/repository/commits/%s/cherry_pick' % (self.project_id,
-                                                                  self.id)
+        url = '/projects/{0:s}/repository/commits/{1:s}/cherry_pick'.format(
+            self.project_id, self.id)
 
         r = self.gitlab._raw_post(url, data={'project_id': self.project_id,
                                              'branch': branch}, **kwargs)

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -1353,6 +1353,20 @@ class ProjectCommit(GitlabObject):
                                      {'project_id': self.project_id},
                                      **kwargs)
 
+    def cherry_pick(self,branch,**kwargs):
+        """Cherry-pick a commit into a branch.
+
+        Args:
+            branch (str): Name of target branch.
+
+        Raises:
+            GitlabCherryPickError: If the cherry pick could not be applied.
+        """
+        url = '/projects/%s/repository/commits/%s/cherry_pick' % (self.project_id,
+                                                                  self.id)
+        r = self.gitlab._raw_post(url, data={'project_id':self.project_id,'branch': branch}, **kwargs)
+        errors = {400: GitlabCherryPickError}
+        raise_error_from_response(r, errors,expected_code=201)
 
 class ProjectCommitManager(BaseManager):
     obj_cls = ProjectCommit


### PR DESCRIPTION
This is a possible implementation for addressing #235. It allows to cherry pick individual commits through the Gitlab API both from the python code as well as from the command line. The documentation has been updated.