### PR TITLE
add 'delete source branch' option when creating MR

### DIFF
--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -1708,7 +1708,7 @@ class ProjectMergeRequest(GitlabObject):
     requiredUrlAttrs = ['project_id']
     requiredCreateAttrs = ['source_branch', 'target_branch', 'title']
     optionalCreateAttrs = ['assignee_id', 'description', 'target_project_id',
-                           'labels', 'milestone_id','remove_source_branch']
+                           'labels', 'milestone_id', 'remove_source_branch']
     optionalUpdateAttrs = ['target_branch', 'assignee_id', 'title',
                            'description', 'state_event', 'labels',
                            'milestone_id']

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -1708,7 +1708,7 @@ class ProjectMergeRequest(GitlabObject):
     requiredUrlAttrs = ['project_id']
     requiredCreateAttrs = ['source_branch', 'target_branch', 'title']
     optionalCreateAttrs = ['assignee_id', 'description', 'target_project_id',
-                           'labels', 'milestone_id']
+                           'labels', 'milestone_id','remove_source_branch']
     optionalUpdateAttrs = ['target_branch', 'assignee_id', 'title',
                            'description', 'state_event', 'labels',
                            'milestone_id']


### PR DESCRIPTION
The Gitlab API provides the possibility to check the option "delete source branch when merge is accepted" [(here)](https://docs.gitlab.com/ce/api/merge_requests.html#create-mr). This PR allows to make use of this API feature.