### PR TITLE
Add support for nested groups

### DIFF
--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -2702,8 +2702,10 @@ class GroupProjectManager(BaseManager):
 class Group(GitlabObject):
     _url = '/groups'
     requiredCreateAttrs = ['name', 'path']
-    optionalCreateAttrs = ['description', 'visibility_level']
-    optionalUpdateAttrs = ['name', 'path', 'description', 'visibility_level']
+    optionalCreateAttrs = ['description', 'visibility_level', 'parent_id',
+                           'lfs_enabled', 'request_access_enabled', 'parent_id']
+    optionalUpdateAttrs = ['name', 'path', 'description', 'visibility_level',
+                           'lfs_enabled', 'request_access_enabled']
     shortPrintAttr = 'name'
     managers = (
         ('accessrequests', GroupAccessRequestManager, [('group_id', 'id')]),

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -2703,7 +2703,7 @@ class Group(GitlabObject):
     _url = '/groups'
     requiredCreateAttrs = ['name', 'path']
     optionalCreateAttrs = ['description', 'visibility_level', 'parent_id',
-                           'lfs_enabled', 'request_access_enabled', 'parent_id']
+                           'lfs_enabled', 'request_access_enabled']
     optionalUpdateAttrs = ['name', 'path', 'description', 'visibility_level',
                            'lfs_enabled', 'request_access_enabled']
     shortPrintAttr = 'name'

--- a/tools/python_test.py
+++ b/tools/python_test.py
@@ -100,8 +100,12 @@ user2 = gl.users.create({'email': 'user2@test.com', 'username': 'user2',
 group1 = gl.groups.create({'name': 'group1', 'path': 'group1'})
 group2 = gl.groups.create({'name': 'group2', 'path': 'group2'})
 
-assert(len(gl.groups.list()) == 2)
+p_id = gl.groups.search('group2')[0].id
+group3 = gl.groups.create({'name': 'group3', 'path': 'group3', 'parent_id': p_id})
+
+assert(len(gl.groups.list()) == 3)
 assert(len(gl.groups.search("1")) == 1)
+assert(group3.parent_id == p_id)
 
 group1.members.create({'access_level': gitlab.Group.OWNER_ACCESS,
                        'user_id': user1.id})


### PR DESCRIPTION
Add `parent_id` attribute support when creating groups, so we can create nested groups.

I'm not sure if this is the only change needed, but it is working on my local copy and I have successfully created nested groups while migrating SVN to GitLab.